### PR TITLE
Bumped upper version bound for base

### DIFF
--- a/split.cabal
+++ b/split.cabal
@@ -51,7 +51,7 @@ Source-repository head
 
 Library
   ghc-options:       -Wall
-  build-depends:     base <4.11
+  build-depends:     base <4.12
   exposed-modules:   Data.List.Split, Data.List.Split.Internals
   default-language:  Haskell2010
   Hs-source-dirs:    src


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). While testing [Agda](https://github.com/agda/agda) with this version of GHC, I got the following error:

```
$ cabal install
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: split-0.2.3.2 (user goal)
next goal: base (dependency of split-0.2.3.2)
rejecting: base-4.11.0.0/installed-4.1... (conflict: split => base<4.11)
...
```

This PR fix the above issue.

Blocking https://github.com/agda/agda/issues/2878.
