### PR TITLE
Fixed compilation with GHC 8.6.1-alpha2

### DIFF
--- a/split.cabal
+++ b/split.cabal
@@ -51,7 +51,7 @@ Source-repository head
 
 Library
   ghc-options:       -Wall
-  build-depends:     base <4.12
+  build-depends:     base <4.13
   exposed-modules:   Data.List.Split, Data.List.Split.Internals
   default-language:  Haskell2010
   Hs-source-dirs:    src


### PR DESCRIPTION
GHC 8.6.1-alpha2 was [announced](https://mail.haskell.org/pipermail/glasgow-haskell-users/2018-July/026776.html). This PR fix the compilation with this version of GHC.

Blocking https://github.com/agda/agda/issues/3160.