### PR TITLE
Support GHC 8.8

### DIFF
--- a/split.cabal
+++ b/split.cabal
@@ -51,7 +51,7 @@ Source-repository head
 
 Library
   ghc-options:       -Wall
-  build-depends:     base <4.13
+  build-depends:     base < 4.14
   exposed-modules:   Data.List.Split, Data.List.Split.Internals
   default-language:  Haskell2010
   Hs-source-dirs:    src


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.