### PR TITLE
Update tested-with and CI to latest minor versions (8.8.4 and 8.10.4)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: 8.10.1
+          - ghc: 8.10.3
             allow-failure: false
-          - ghc: 8.8.2
+          - ghc: 8.8.4
             allow-failure: false
           - ghc: 8.6.5
             allow-failure: false

--- a/README
+++ b/README
@@ -9,7 +9,7 @@ Dependencies:
 
   There are no dependencies other than the base package.
   Data.List.Split has been tested with versions of GHC from 6.8.3 up
-  through 8.0.1.  It is completely Haskell2010 (probably also
+  through 9.0.1.  It is completely Haskell2010 (probably also
   Haskell98) compliant, so it probably builds with other compilers as
   well.
 

--- a/split.cabal
+++ b/split.cabal
@@ -35,7 +35,7 @@ Maintainer:          byorgey@gmail.com
 Category:            List
 Build-type:          Simple
 Cabal-Version:       >= 1.10
-Tested-with:         GHC ==7.0.4 || ==7.2.2 || ==7.4.2 || ==7.6.3 || ==7.8.4 || ==7.10.3 || ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.2 || ==8.10.1 || ==9.0.1
+Tested-with:         GHC ==7.0.4 || ==7.2.2 || ==7.4.2 || ==7.6.3 || ==7.8.4 || ==7.10.3 || ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 Bug-reports:         https://github.com/byorgey/split/issues
 
 Test-suite split-tests


### PR DESCRIPTION
Update tested-with and CI to latest minor versions (8.8.4 and 8.10.4)

Note: latest CI is 8.10.3 (afaik), but locally I tested 8.10.4 and 9.0.1 as well.