### PR TITLE
Add GHC-9.0 job (newer haskell-ci knows about GHC-9.0)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20210218
+# version: 0.11.20210220
 #
-# REGENDATA ("0.11.20210218",["github","split.cabal"])
+# REGENDATA ("0.11.20210220",["github","split.cabal"])
 #
 name: Haskell-CI
 on:
@@ -26,9 +26,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: 8.10.1
+          - ghc: 9.0.1
             allow-failure: false
-          - ghc: 8.8.2
+          - ghc: 8.10.4
+            allow-failure: false
+          - ghc: 8.8.4
             allow-failure: false
           - ghc: 8.6.5
             allow-failure: false
@@ -58,7 +60,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2
+          apt-get install -y ghc-$GHC_VERSION cabal-install-3.4
         env:
           GHC_VERSION: ${{ matrix.ghc }}
       - name: Set PATH and environment variables
@@ -71,13 +73,13 @@ jobs:
           echo "HC=$HC" >> $GITHUB_ENV
           echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
           echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.2/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
           echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
+          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
           GHC_VERSION: ${{ matrix.ghc }}

--- a/split.cabal
+++ b/split.cabal
@@ -35,7 +35,7 @@ Maintainer:          byorgey@gmail.com
 Category:            List
 Build-type:          Simple
 Cabal-Version:       >= 1.10
-Tested-with:         GHC ==7.0.4 || ==7.2.2 || ==7.4.2 || ==7.6.3 || ==7.8.4 || ==7.10.3 || ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.2 || ==8.10.1 || ==9.0.1
+Tested-with:         GHC ==7.0.4 || ==7.2.2 || ==7.4.2 || ==7.6.3 || ==7.8.4 || ==7.10.3 || ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.4 || ==8.10.4 || ==9.0.1
 Bug-reports:         https://github.com/byorgey/split/issues
 
 Test-suite split-tests


### PR DESCRIPTION
I'd also kindly ask to not make a release, but consider just making [a *revision*](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md).